### PR TITLE
enable rostermatic when config.json includes farm: true

### DIFF
--- a/server/server.coffee
+++ b/server/server.coffee
@@ -35,7 +35,7 @@ startServer = (params) ->
       done null, site
 
   farm = (req, res, next) ->
-    if argv.f
+    if argv.farm
       next()
     else
       res.status(404).send {error: 'service requires farm mode'}


### PR DESCRIPTION
Rostermatic does not correctly detect that wiki farm is enabled despite having the following in `.wiki/config.json`
```
{
  ...
  farm: true,
  ...
}
```

This minor change made Rostermatic work as I expected.

Because the `-f` option for the CLI is an alias of `--farm`,
I think this expression should work for all the cases.